### PR TITLE
Update Electron WebRequest API links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ require('nightmare-load-filter')(Nightmare);
 ```
 
 ### .filter(filter, fn)
-Adds a prerequest call to `fn` filtered to the URLs specified in `filter`.  The `fn` parameter must be a function that accepts details and a callback.  When complete, the callback must specify a response object, even if it is empty.  Note that `filter` is of the same form and works in the same way that the [Electron filter does](https://github.com/atom/electron/blob/master/docs/api/session.md#seswebrequest).  See the [`onBeforeRequest` documentation](https://github.com/atom/electron/blob/master/docs/api/session.md#seswebrequestonbeforerequestfilter-listener) in the Electron documentation for more information.
+Adds a prerequest call to `fn` filtered to the URLs specified in `filter`.  The `fn` parameter must be a function that accepts details and a callback.  When complete, the callback must specify a response object, even if it is empty.  Note that `filter` is of the same form and works in the same way that the [Electron filter does](https://github.com/electron/electron/blob/v1.6.5/docs/api/web-request.md).  See the [`onBeforeRequest` documentation](https://github.com/electron/electron/blob/v1.6.5/docs/api/web-request.md#webrequestonbeforerequestfilter-listener) in the Electron documentation for more information.
 
 ## Example
 


### PR DESCRIPTION
I was just passing through the repo from https://github.com/segmentio/nightmare/issues/540 and had to hop around the electron API docs to find the appropriate references.

Resolves #3 