### PR TITLE
Allow optional arguments to be sent along with the filter function

### DIFF
--- a/nightmare-load-filter.js
+++ b/nightmare-load-filter.js
@@ -3,23 +3,24 @@ var debug = require('debug')('nightmare:load-filter');
 module.exports = exports = function(Nightmare) {
   Nightmare.action('filter',
     function(name, options, parent, win, renderer, done) {
-      parent.on('filter', function(filter, filterFunction) {
+      parent.on('filter', function(filter, filterFunction, args) {
         win.webContents.session.webRequest.onBeforeRequest(filter, function(details, cb) {
           parent.emit('log', 'load-filter', details);
           var fn = new Function('with(this){return ' + filterFunction + '}')
             .call({});
-          fn(details, cb);
+          fn(details, cb, ...args);
         });
         parent.emit('filter');
       });
       done();
       return this;
     },
-    function(filter, filterFunction, done) {
+    function(filter, filterFunction, ...args) {
+      let done = args.pop();
       //emit the filter to the child process
       debug('issuing filter: ' + require('util')
         .inspect(filter));
       this.child.once('filter', done);
-      this.child.emit('filter', filter, String(filterFunction));
+      this.child.emit('filter', filter, String(filterFunction), args);
     });
 };


### PR DESCRIPTION
This allows custom arguments to be sent to the filter function. It works similar to the existing Nightmare api, meaning that you place the arguments you want to send after the filter function when you are calling `nightmare.filter`. Then, the arguments are available to your filter function as normal parameters that appear after the electron callback. 

Example use case that this pull request enables: 
```js
nightmare.filter({ urls: ['*'] }, (details, handler, resources) => {
  let cancel = ['mainFrame', ...resources].every(type => details.resourceType !== type)
  return handler({ cancel })
}, resources)
```